### PR TITLE
Skip parsing req body for project creation

### DIFF
--- a/pages/api/projects/create.ts
+++ b/pages/api/projects/create.ts
@@ -8,9 +8,7 @@ import { Project } from "@/types/data/Project";
 import { getCtx } from "@/api/ctx/apiCtx";
 import { identifyUser } from "@/api/utils/identifyUser";
 
-import { parse } from "@/utils/parse";
 import { standardizeResponse } from "@/utils/standardizeResponse";
-
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const ctx = await getCtx();
@@ -18,7 +16,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
 
   if (data === OperationStatus.Error) return res.status(401).end();
 
-  const body: Pick<Project, "name"> = parse(req.body, { name: "" });
+  const body: Pick<Project, "name"> = req.body;
 
   if (!body.name?.trim())
     return res.status(400).json({ exception: "INVALID_REQUEST_BODY" });


### PR DESCRIPTION
**Changelog** 

- [X] Skip parsing req body for project creation as `req.body` is not a string, rather it's an object.