### PR TITLE
Fix download from web3 storage

### DIFF
--- a/src/handlers/contracts/verify/utils/downloadFile.ts
+++ b/src/handlers/contracts/verify/utils/downloadFile.ts
@@ -1,32 +1,23 @@
 import fs from "fs";
 import { Writable } from "stream";
 
-import { ApiCtx } from "@/api/ctx/apiCtx";
-
 // downloadFile downloads single file from web3.storage
 export const downloadFile = async (
-  ctx: ApiCtx,
   cid: string,
-  filePath: string
+  filePath: string,
+  fileName?: string
 ): Promise<string> => {
-  const response = await ctx.web3storage.get(cid);
+  // NOTE: Downloads file from w3s.link instead of using web3.storage client
+  const url = fileName
+    ? `https://w3s.link/ipfs/${cid}/${fileName}`
+    : `https://w3s.link/ipfs/${cid}`;
+
+  const response = await fetch(url);
   if (!response?.ok) {
-    console.log(response);
     throw new Error("Failed to fetch file from web3.storage");
   }
 
-  const responseFiles = await response?.files();
-
-  if (!responseFiles || responseFiles.length === 0) {
-    throw new Error("No files found in response");
-  }
-
-  // assume we only have one file uploaded to web3.storage per cid
-  if (responseFiles.length > 1) {
-    throw new Error("Too many files found in response");
-  }
-
-  const blob = responseFiles[0];
+  const blob = await response.blob();
 
   // TODO: Make this limit configurable (currently 100MB)
   if (blob.size > 1e8) {

--- a/src/handlers/contracts/verify/utils/processRequestBody.ts
+++ b/src/handlers/contracts/verify/utils/processRequestBody.ts
@@ -1,7 +1,11 @@
 import { Request } from "express";
 import { VerificationRequest } from "@/handlers/contracts/verify/types/VerificationRequest";
+import { SolidityVersion } from "@/enums/SolidityVersion";
 
 export const processRequestBody = (req: Request) => {
   // TODO: Add validation of CID, etc
-  return req.body as VerificationRequest;
+  const { body } = req;
+  // Default to latest solidity version
+  const solidityVersion = body.solidityVersion || SolidityVersion.Latest;
+  return { ...body, solidityVersion } as VerificationRequest;
 };

--- a/src/ui/external/useWeb3Storage.ts
+++ b/src/ui/external/useWeb3Storage.ts
@@ -16,8 +16,12 @@ export const useWeb3Storage = <T = unknown>() => {
     progress: 0,
   });
 
-  const upload = (file: File) => {
+  const upload = (inputFile: File, fileNameOverride?: string) => {
     setState((p) => set(lensPath(["loading"]), true)(p));
+
+    let file = new File([inputFile], fileNameOverride || inputFile.name, {
+      type: inputFile.type,
+    });
 
     let uploaded = 0;
 

--- a/src/ui/modules/SelectedEntity/components/ContractPage/components/VerifyContract.tsx
+++ b/src/ui/modules/SelectedEntity/components/ContractPage/components/VerifyContract.tsx
@@ -87,7 +87,7 @@ export const VerifyContract = ({
       );
     }
 
-    upload(data.source);
+    upload(data.source, "contracts.zip");
   }, [valid, data]);
 
   useEffect(() => {


### PR DESCRIPTION
**Description**

Due to web3.storage arhitecture some files are not available immediatly to download via API after the upload. To solve this problem web3 storage IPFS gateway can be used to fetch recently uploaded file.

https://github.com/web3-storage/web3.storage/issues/1810

**Changelog**

- [X] Download from web3 storage IPFS gateway instead of using API
- [X] Rename zip file to `contracts.zip` when uploading to web3 storage
- [X] Return error instead of raising exception and catching it locally 