### PR TITLE
Lotus retry on failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "start:custom": "cross-env NODE_ENV=production node dist/server.js"
   },
   "dependencies": {
+    "@adobe/node-fetch-retry": "^2.2.0",
     "@clickhouse/client": "^0.0.11",
     "@filecoin-shipyard/lotus-client-provider-nodejs": "^1.1.1",
     "@filecoin-shipyard/lotus-client-rpc": "^1.2.0",

--- a/src/api/ctx/config/lotus.config.ts
+++ b/src/api/ctx/config/lotus.config.ts
@@ -1,8 +1,10 @@
 import { Network } from "@/enums/Network";
+import { RetryOptions } from "@adobe/node-fetch-retry";
 
 export type LotusConfig = {
   url: string;
   token?: string;
+  retryOptions?: Pick<RetryOptions, "socketTimeout" | "retryMaxDuration">;
 };
 
 const lotusWallabyConfig: (env?: typeof process.env) => LotusConfig = (
@@ -10,6 +12,14 @@ const lotusWallabyConfig: (env?: typeof process.env) => LotusConfig = (
 ) => ({
   url: process.env.WALLABY_LOTUS_URL as string,
   token: process.env.WALLABY_LOTUS_TOKEN as string,
+  retryOptions: {
+    socketTimeout: +(process.env.LOTUS_SOCKET_TIMEOUT || 180000),
+    // Without retryMaxDuration defined it will default to 60000ms and socketTimeout
+    // will default to 30000ms if socketTimeout >= retryMaxDuration
+    // We set retryMaxDuration to 5 x of socketTimeout value,
+    // hence making it possible to retry max 5 times before request timing out.
+    retryMaxDuration: +(process.env.LOTUS_SOCKET_TIMEOUT || 180000) * 5,
+  },
 });
 
 const lotusHyperspaceConfig: (env?: typeof process.env) => LotusConfig = (
@@ -17,6 +27,14 @@ const lotusHyperspaceConfig: (env?: typeof process.env) => LotusConfig = (
 ) => ({
   url: process.env.HYPERSPACE_LOTUS_URL as string,
   token: process.env.HYPERSPACE_LOTUS_TOKEN as string,
+  retryOptions: {
+    socketTimeout: +(process.env.LOTUS_SOCKET_TIMEOUT || 180000),
+    // Without retryMaxDuration defined it will default to 60000ms and socketTimeout
+    // will default to 30000ms if socketTimeout >= retryMaxDuration
+    // We set retryMaxDuration to 5 x of socketTimeout value,
+    // hence making it possible to retry max 5 times before request timing out.
+    retryMaxDuration: +(process.env.LOTUS_SOCKET_TIMEOUT || 180000) * 5,
+  },
 });
 
 export default (env = process.env) => ({

--- a/src/api/ctx/lotus/client/index.ts
+++ b/src/api/ctx/lotus/client/index.ts
@@ -1,14 +1,21 @@
+import fetch from "@adobe/node-fetch-retry";
 // @ts-ignore
 import { NodejsProvider } from "@filecoin-shipyard/lotus-client-provider-nodejs";
 import { LotusRPC } from "@filecoin-shipyard/lotus-client-rpc";
 
 import { LotusConfig } from "@/api/ctx/config/lotus.config";
-import { LotusClient } from "@/api/ctx/lotus/client/typings/lotus-client-rpc";
 import { CustomSchema } from "@/api/ctx/lotus/client/schemas/custom.schema";
-
+import { LotusClient } from "@/api/ctx/lotus/client/typings/lotus-client-rpc";
 
 export const getLotusClient = (config: LotusConfig): LotusClient => {
-  const provider = new NodejsProvider(config.url, { token: config.token, sendHttpContentType: 'application/json' });
+  const fetchRetry: typeof fetch = (url, init) =>
+    fetch(url, { ...init, retryOptions: config.retryOptions });
+
+  const provider = new NodejsProvider(config.url, {
+    token: config.token,
+    sendHttpContentType: "application/json",
+    fetch: fetchRetry,
+  });
   return new LotusRPC(provider, {
     schema: CustomSchema,
   }) as LotusClient;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,14 @@
   resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.2.0.tgz#e1a84fca468f4b337816fcb7f0964beb620ba855"
   integrity sha512-E09FiIft46CmH5Qnjb0wsW54/YQd69LsxeKUOWawmws1XWvyFGURnAChH0mlr7YPFR1ofwvUQfcL0J3lMxXqPA==
 
+"@adobe/node-fetch-retry@^2.2.0":
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/@adobe/node-fetch-retry/-/node-fetch-retry-2.2.0.tgz#08fe9cc1885de8c0ac4b9157ed26ea07691dd90d"
+  integrity sha512-4sNIVGL26G2vzFA+O/CC2Y5dBG6P7QCTuNr/3pRpo1vJUlPt6aiyhlE/wPYR7WF/MSK+y6hkqqjnRMk5/Myfhg==
+  dependencies:
+    abort-controller "^3.0.0"
+    node-fetch "^2.6.7"
+
 "@ampproject/remapping@^2.1.0", "@ampproject/remapping@^2.2.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"


### PR DESCRIPTION
**Description**
We are having issues as lotus nodes sometimes cannot resolve actor based on actor ID, but messages for that actor can be found in blocks. I've added a retry mechanism, like the one we can fould in filmine allowance protocol, to retry requests on exception.

**Changelog**
- [X] Add fetch retry on lotus client. Retry on failure.